### PR TITLE
core+docs: no-op, clean ups

### DIFF
--- a/core/src/main/scala/fi/sn127/tackler/model/Posting.scala
+++ b/core/src/main/scala/fi/sn127/tackler/model/Posting.scala
@@ -33,14 +33,15 @@ final case class Posting(
   override
   def toString: String = {
     val missingSign = if (amount < 0) "" else " "
-    "   " + acctn.toString + "  " +
+    acctn.toString + "  " +
       missingSign + amount.toString() +
       comment.map(c => " ; " + c).getOrElse("")
   }
 }
 
 object Posting {
-  def sumPosts(posts: Posts): BigDecimal = {
+
+  def sum(posts: Posts): BigDecimal = {
     posts.foldLeft(BigDecimal(0))(_ + _.amount)
   }
 }

--- a/core/src/main/scala/fi/sn127/tackler/model/Transaction.scala
+++ b/core/src/main/scala/fi/sn127/tackler/model/Transaction.scala
@@ -36,22 +36,22 @@ final case class Transaction(
   comments: Option[List[String]],
   posts: Posts) {
 
-  if (BigDecimal(0).compareTo(Posting.sumPosts(posts)) =!= 0) {
-    throw new TxnException("TXN postings do not zero: " + Posting.sumPosts(posts).toString())
+  if (BigDecimal(0).compareTo(Posting.sum(posts)) =!= 0) {
+    throw new TxnException("TXN postings do not zero: " + Posting.sum(posts).toString())
   }
 
   /**
    * Txn sorting logic.
    *
-   * Input order of Txn is not significant, so there should
+   * Input order of Txn can not be mandated, so there should
    * be a stable way to sort transactions.
    *
    * Txn components are used in following order to find sort order
-   * (in case of previous components have been same):
-   *  date, code, description, uuid
+   * (in case of previous components have produced "same" sort order):
+   *  timestamp, code, description, uuid
    *
-   * If fully deterministic sort order is needed, then transactions must have
-   * uuid field.
+   * If fully deterministic and safe "distributed txn source"-proof
+   * sort order is needed, then transactions must have UUIDs.
    *
    * @param otherTxn to be compared to this Txn
    * @return 0 if the argument txn is equal to this Txn.
@@ -78,6 +78,13 @@ final case class Transaction(
     }
   }
 
+  /**
+   * Get header part of txn as string.
+   *
+   * @param indent indent string for meta and comment parts
+   * @param tsFormatter timestamp formatter
+   * @return new line terminated header of txn
+   */
   def txnHeaderToString(indent: String, tsFormatter: (ZonedDateTime => String)): String = {
     val codeStr = code.map(c => " (" + c + ") ")
 
@@ -95,6 +102,6 @@ final case class Transaction(
     val indent = " " * 3
 
     txnHeaderToString(indent, TxnTS.isoZonedTS) +
-      posts.map(p => p.toString).mkString("\n") + "\n"
+      posts.map(p => indent + p.toString).mkString("\n") + "\n"
   }
 }

--- a/core/src/main/scala/fi/sn127/tackler/parser/TacklerTxns.scala
+++ b/core/src/main/scala/fi/sn127/tackler/parser/TacklerTxns.scala
@@ -152,7 +152,7 @@ class TacklerTxns(val settings: Settings) {
 
     val last_posting = Option(txnCtx.postings().last_posting()).map(lp => {
         val ate = handleAccount(lp.account())
-        val amount = Posting.sumPosts(posts)
+        val amount = Posting.sum(posts)
         val comment = Option(lp.comment()).map(c => c.text().getText)
         List(Posting(ate, -amount, comment))
       })

--- a/core/src/main/scala/fi/sn127/tackler/report/BalanceReport.scala
+++ b/core/src/main/scala/fi/sn127/tackler/report/BalanceReport.scala
@@ -78,10 +78,10 @@ class BalanceReport(val name: String, val settings: Settings) extends  BalanceRe
   def doReport(formats: Formats, txns: Txns): Unit = {
     val txtBalanceReport = txtReporter(txns)(txtBalance)
 
-    formats.foreach({case (format, w ) =>
+    formats.foreach({case (format, writers) =>
       format match {
         case TextFormat() =>
-          textWriter(w, txtBalanceReport)
+          doRowOutputs(writers, txtBalanceReport)
 
         //case JsonFormat() => ???
       }
@@ -149,10 +149,10 @@ class BalanceGroupReport(val name: String, val settings: Settings) extends Balan
 
     val txtBalgrpReport = txtBalanceGroups(txns)
 
-    formats.foreach({case (format, w ) =>
+    formats.foreach({case (format, writers) =>
       format match {
         case TextFormat() =>
-          textWriter(w, txtBalgrpReport)
+          doRowOutputs(writers, txtBalgrpReport)
 
         //case JsonFormat() => ???
       }

--- a/core/src/main/scala/fi/sn127/tackler/report/EquityReport.scala
+++ b/core/src/main/scala/fi/sn127/tackler/report/EquityReport.scala
@@ -49,6 +49,6 @@ class EquityReport(val settings: Settings) extends ExportLike {
   def doExport(writer: Writer, txns: Txns): Unit = {
 
     val txtEqReport = txnEquity(txns)
-    txnWriter(writer, txtEqReport)
+    doRowOutput(writer, txtEqReport)
   }
 }

--- a/core/src/main/scala/fi/sn127/tackler/report/ExportLike.scala
+++ b/core/src/main/scala/fi/sn127/tackler/report/ExportLike.scala
@@ -16,19 +16,9 @@
  */
 package fi.sn127.tackler.report
 
-import fi.sn127.tackler.core.Settings
 import fi.sn127.tackler.model.Txns
 
-trait ExportLike {
-  val settings: Settings
-
-  protected def txnWriter(writer: Writer, rows: Seq[String]): Unit = {
-    rows.foreach(row => {
-      writer.write(row)
-      writer.write("\n")
-    })
-    writer.flush()
-  }
+trait ExportLike extends OutputLike {
 
   def doExport(writer: Writer, txns: Txns): Unit
 }

--- a/core/src/main/scala/fi/sn127/tackler/report/OutputLike.scala
+++ b/core/src/main/scala/fi/sn127/tackler/report/OutputLike.scala
@@ -17,13 +17,23 @@
 package fi.sn127.tackler.report
 
 import fi.sn127.tackler.core.Settings
-import fi.sn127.tackler.model.Txns
 
-class IdentityReport(val settings: Settings) extends ExportLike {
+trait OutputLike {
+  val settings: Settings
 
-  def doExport(writer: Writer, txns: Txns): Unit = {
-    txns.foreach(txn => {
-      doRowOutput(writer, List(txn.toString))
+  /**
+   * Output of multiple rows to single output.
+   * This uses hardcoded LF line endings.
+   * Writer is flushed after all rows are written.
+   *
+   * @param writer to do output
+   * @param rows to be output
+   */
+  protected def doRowOutput(writer: Writer, rows: Seq[String]): Unit = {
+    rows.foreach(row => {
+      writer.write(row)
+      writer.write("\n")
     })
+    writer.flush()
   }
 }

--- a/core/src/main/scala/fi/sn127/tackler/report/RegisterReport.scala
+++ b/core/src/main/scala/fi/sn127/tackler/report/RegisterReport.scala
@@ -49,13 +49,13 @@ class RegisterReport(val name: String, val settings: Settings) extends ReportLik
   }
 
   private def doHeaders(formats: Formats): Unit = {
-    formats.foreach({case (format, w ) =>
+    formats.foreach({case (format, writers) =>
       format match {
         case TextFormat() =>
           val reportHeader = List(
             mySettings.title,
             "-" * mySettings.title.length)
-          textWriter(w, reportHeader)
+          doRowOutputs(writers, reportHeader)
 
         //case JsonFormat() => ???
       }
@@ -65,11 +65,11 @@ class RegisterReport(val name: String, val settings: Settings) extends ReportLik
   private def doBody(formats: Formats, filter: Filtering[RegisterPosting], txns: Txns): Unit = {
 
     Accumulator.registerStream(txns)({regEntry: RegisterEntry =>
-      formats.foreach({case (format, w) =>
+      formats.foreach({case (format, writers) =>
         format match {
           case TextFormat() =>
             val txtRegEntry = txtRegisterEntry(regEntry, filter)
-            textWriter(w, txtRegEntry)
+            doRowOutputs(writers, txtRegEntry)
 
           //case JsonFormat() => ???
         }

--- a/core/src/main/scala/fi/sn127/tackler/report/ReportLike.scala
+++ b/core/src/main/scala/fi/sn127/tackler/report/ReportLike.scala
@@ -16,13 +16,11 @@
  */
 package fi.sn127.tackler.report
 
-import fi.sn127.tackler.core.Settings
 import fi.sn127.tackler.model.Txns
 
-trait ReportLike {
-  val settings: Settings
+trait ReportLike extends OutputLike {
   /**
-   * Name of output file.
+   * Report name part of output filename.
    */
   val name: String
 
@@ -73,14 +71,15 @@ trait ReportLike {
     getFillFormat(width, v).format(v)
   }
 
-  def textWriter(writers: Writers, rows: Seq[String]): Unit = {
-
+  /**
+   * Output multiple rows to multiple outputs
+   *
+   * @param writers sequence of outputs
+   * @param rows to be output
+   */
+  protected def doRowOutputs(writers: Writers, rows: Seq[String]): Unit = {
     writers.foreach(w => {
-      rows.foreach(row => {
-        w.write(row)
-        w.write("\n")
-      })
-      w.flush()
+      doRowOutput(w, rows)
     })
   }
 

--- a/core/src/test/scala/fi/sn127/tackler/model/PostingTest.scala
+++ b/core/src/test/scala/fi/sn127/tackler/model/PostingTest.scala
@@ -49,7 +49,7 @@ class PostingTest extends FlatSpec {
       BigDecimal("123456789012345678901234567890.123456789012345678901234567890123456789012")
     val p = Posting(acctn, v, None)
 
-    assert(p.toString === "   a:b   123456789012345678901234567890.123456789012345678901234567890123456789012")
+    assert(p.toString === "a:b   123456789012345678901234567890.123456789012345678901234567890123456789012")
   }
 
   /**
@@ -59,6 +59,6 @@ class PostingTest extends FlatSpec {
     val v = BigDecimal("123.01")
     val p = Posting(acctn, v, Some("comment"))
 
-    assert(p.toString === "   a:b   123.01 ; comment")
+    assert(p.toString === "a:b   123.01 ; comment")
   }
 }

--- a/docs/devel/design.adoc
+++ b/docs/devel/design.adoc
@@ -102,3 +102,17 @@ Parser definition is located
 Converting from ANTLR Parser Context to the Tackler Model is done
 by link:../../core/src/main/scala/fi/sn127/tackler/parser/TacklerTxns.scala[core / parser / TacklerTxns]
 helper class.
+
+== Input
+
+Input order of Txn can not be mandated. So there should be a stable way to sort transactions if
+internal order (e.g. order of txns during one day and without time information)
+is important.  In that case it is mandatory to provide  unique sorting information for each transaction.
+
+Txn components are used in following order to find sort order
+(in case of previous components have produced "same" sort order):
+
+ timestamp, code, description, uuid
+
+If fully deterministic and safe "distributed txn source"-proof sort
+order is needed, then transactions must have UUIDs.

--- a/docs/report-identity.adoc
+++ b/docs/report-identity.adoc
@@ -4,7 +4,14 @@ Identity report produces an export of transactions as they are interpreted by Ta
 
 This report is valid input for Tackler, so it can be used for example archiving purposes.
 
-If internal order of transaction stream is important, then it is mandatory to provide
-unique sorting information for each transaction. This means that each Txns must have
-either `uuid` meta info field, or unique combination of `time`, `code` and `description`
-field values (it is enough that combination or one field of above is unique).
+Input order of Txn can not be mandated. So there should be a stable way to sort transactions if
+internal order of identity report (e.g. order of txns during one day and without time information)
+is important.  In that case it is mandatory to provide  unique sorting information for each transaction.
+
+Txn components are used in following order to find sort order
+(in case of previous components have produced "same" sort order):
+
+ timestamp, code, description, uuid
+
+If fully deterministic and safe "distributed txn source"-proof sort
+order is needed, then transactions must have UUIDs.

--- a/docs/report-register.adoc
+++ b/docs/report-register.adoc
@@ -5,11 +5,17 @@ Register report is report with running total of transactions
 On left amount column, there is posting amount and on right running total for that account.
 Register report is good way to find oddities and anomalies withing accounting data.
 
-If internal order of register report (e.g. order of txns during one day and without time information)
-is important, then it is mandatory to provide  unique sorting information for each transaction.
-This means that each Txns must have  either `uuid` meta info field, or unique
-combination of `time`, `code` and `description`  field values
-(it is enough that combination or one field of above is unique).
+Input order of Txn can not be mandated. So there should be a stable way to sort transactions if
+internal order of register report (e.g. order of txns during one day and without time information)
+is important.  In that case it is mandatory to provide  unique sorting information for each transaction.
+
+Txn components are used in following order to find sort order
+(in case of previous components have produced "same" sort order):
+
+ timestamp, code, description, uuid
+
+If fully deterministic and safe "distributed txn source"-proof sort
+order is needed, then transactions must have UUIDs.
 
 Currently register report prints each transaction's time with date resolution,
 but this will change in future (there will be an option to control register report's


### PR DESCRIPTION
 - model: clean up Txn and Posting outputs
 - report: clean up and refactor output writers
 - docs: clarify Txn sorting

Signed-off-by: jaa127 <jaa@sn127.fi>